### PR TITLE
Group pagination dots by visual pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,5 @@ release: validate tests build ghpages
 	node_modules/.bin/np \
 		--no-yarn \
 		--no-tests \
+		--any-branch \
 		--tag

--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ The pagination can be customized by additional options. The following options ar
 * `paginationClassName` – a string which represents the class name for the `<ul>` element of the pagination – Default value is: `'pagination'`
 * `paginationLabel` – a function which returns a string for the label of each button inside the pagination. A data object is passed as param into the invoked function, containing information about:
     * `index` – a number of the current item index
-    * `item` – a dom element reference to the related item
-    * `items` – a dom element list of all items
+	* `pages` – all existing pages, a list of grouped indexes
+    * `page` – the current page
 * `paginationTitle` – a function which returns a string for the title of each button inside the pagination. A data object is passed as param into the invoked function, containing information about:
     * `index` – a number of the current item index
-    * `item` – a dom element reference to the related item
-    * `items` – a dom element list of all items
+    * `pages` – all existing pages, a list of grouped indexes
+    * `page` – the current page
 * `paginationTemplate`– is a function which returns an HTML-string of the complete pagination. The default implementation invokes the `paginationLabel` and `paginationTitle` functions to create the string. A data object is passed as param into the invoked function, containing information about:
     * `className` – a string with the value of the `paginationClassName` option.
     *  `controls` – a string reference to the HTML id of the carousel element. this is relevant for an `aria-controls="..."` attribute.
-    * `items` – a dom element list of all items
+    * `pages` – all existing pages, a list of grouped indexes
     * `label` – the function reference for `paginationLabel` to create a button label
     * `title` – the function reference for `paginationTitle` to create a button tile
 
@@ -159,9 +159,9 @@ const carousel = new Carousel(el, {
     paginationClassName: 'my-pagination',
     paginationLabel: ({index}) => `${index + 1}.`,
     paginationTitle: ({index}) => `Jump to ${index + 1}. item`,
-    paginationTemplate: ({className, items, label, title}) =>
+    paginationTemplate: ({className, pages, label, title}) =>
         `<div class="${className}">
-            ${items.map((item, index) =>
+            ${pages.map((page, index) =>
                 `<button title="${title({index})}">${label({index})}</button>`
             ).join('')}
         </div>`
@@ -217,6 +217,10 @@ Returns and/or sets the current index of the carousel. The returned index is a l
 #### `.items` (read only)
 
 Returns an array of all child dom elements of the carousel.
+
+#### `.pages` (read only)
+
+Returns an array of all pages. Each page is a group of indexes that matches a page.
 
 #### `.id` (read only)
 

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Caroucssel buttons should add buttons 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"height: calc(100% + 0px); margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -23,7 +23,7 @@ exports[`Caroucssel buttons should add buttons 1`] = `
 exports[`Caroucssel buttons should add buttons with custom options 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"height: calc(100% + 0px); margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -43,7 +43,7 @@ exports[`Caroucssel buttons should add buttons with custom options 1`] = `
 exports[`Caroucssel buttons should add buttons with custom template 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"custom-id\\" style=\\"margin-bottom: 0px;\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"custom-id\\" style=\\"height: calc(100% + 0px); margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -59,7 +59,7 @@ exports[`Caroucssel buttons should add buttons with custom template 1`] = `
 exports[`Caroucssel pagination should add pagination 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"height: calc(100% + 0px); margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -70,15 +70,15 @@ exports[`Caroucssel pagination should add pagination 1`] = `
 			</div></div>
 		<ul class=\\"pagination\\">
 		<li>
-				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to 1. item\\" title=\\"Go to 1. item\\" disabled=\\"\\">
+				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to 1. page\\" title=\\"Go to 1. page\\" disabled=\\"\\">
 					<span>1</span>
 				</button>
 			</li><li>
-				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to 2. item\\" title=\\"Go to 2. item\\">
+				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to 2. page\\" title=\\"Go to 2. page\\">
 					<span>2</span>
 				</button>
 			</li><li>
-				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to 3. item\\" title=\\"Go to 3. item\\">
+				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to 3. page\\" title=\\"Go to 3. page\\">
 					<span>3</span>
 				</button>
 			</li>
@@ -89,7 +89,7 @@ exports[`Caroucssel pagination should add pagination 1`] = `
 exports[`Caroucssel pagination should add pagination with custom options 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"height: calc(100% + 0px); margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -119,7 +119,7 @@ exports[`Caroucssel pagination should add pagination with custom options 1`] = `
 exports[`Caroucssel pagination should add pagination with custom template 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"height: calc(100% + 0px); margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -130,13 +130,13 @@ exports[`Caroucssel pagination should add pagination with custom template 1`] = 
 			</div></div>
 		<div class=\\"custom-pagination-class\\" aria-controls=\\"caroucssel-1\\">
 						
-							<div class=\\"item\\" aria-label=\\"Go to first item\\">
+							<div class=\\"item\\" aria-label=\\"Go to first page\\">
 								first
 							</div>
-							<div class=\\"item\\" aria-label=\\"Go to second item\\">
+							<div class=\\"item\\" aria-label=\\"Go to second page\\">
 								second
 							</div>
-							<div class=\\"item\\" aria-label=\\"Go to third item\\">
+							<div class=\\"item\\" aria-label=\\"Go to third page\\">
 								third
 							</div>
 					</div></div>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,8 +15,8 @@ export type ButtonOptions = {
 
 export type PaginationTextParams = {
 	index: number;
-	item: Element;
-	items: Element[];
+	page: number[];
+	pages: number[][];
 };
 
 export type PaginationText = (params: PaginationTextParams) => string;
@@ -26,7 +26,7 @@ export type PaginationParams = {
 	className: string;
 	label: PaginationText;
 	title: PaginationText;
-	items: Element[];
+	pages: number[][];
 };
 
 export type PaginationTemplate = (params: PaginationParams) => string;
@@ -82,6 +82,7 @@ export class Carousel {
 	public get index(): number[];
 	public set index(values: number[]);
 	public get items(): Element[];
+	public get pages(): number[][];
 	public destroy(): void;
 	public update(): void;
 

--- a/src/index.js
+++ b/src/index.js
@@ -369,7 +369,7 @@ export class Carousel {
 		});
 
 		// @TODO: Add template for buttons:
-		const buttons = [...pagination.querySelectorAll('button')]
+		const buttons = Array.from(pagination.querySelectorAll('button'))
 			.map((button, index) => {
 				button.onclick = () => this.index = pages[index];
 				return button;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -344,7 +344,6 @@ describe('Caroucssel', () => {
 		it('should add pagination with custom options', () => {
 			document.body.innerHTML = __fixture(3);
 			const el = document.querySelector('.caroucssel');
-			const items = [...el.children];
 			const options = {
 				hasPagination: true,
 				paginationClassName: 'custom-pagination-class',
@@ -372,10 +371,18 @@ describe('Caroucssel', () => {
 			expect(document.body.innerHTML).toMatchSnapshot();
 
 			expect(options.paginationLabel).toHaveBeenCalledTimes(3);
-			expect(options.paginationLabel).toHaveBeenNthCalledWith(1, {index: 0, item: items[0], items});
+			expect(options.paginationLabel).toHaveBeenNthCalledWith(1, {
+				index: 0,
+				page: [0],
+				pages: [[0], [1], [2]],
+			});
 
 			expect(options.paginationTitle).toHaveBeenCalledTimes(3);
-			expect(options.paginationTitle).toHaveBeenNthCalledWith(3, {index: 2, item: items[2], items});
+			expect(options.paginationTitle).toHaveBeenNthCalledWith(3, {
+				index: 2,
+				page: [2],
+				pages: [[0], [1], [2]],
+			});
 		});
 
 		it('should add pagination with custom template', () => {
@@ -400,11 +407,11 @@ describe('Caroucssel', () => {
 						case 2: name = 'third'; break;
 						default: name = 'un-defined'; break;
 					}
-					return `Go to ${name} item`;
+					return `Go to ${name} page`;
 				}),
-				paginationTemplate: jest.fn(({className, controls, items, label, title}) =>
+				paginationTemplate: jest.fn(({className, controls, pages, label, title}) =>
 					`<div class="${className}" aria-controls="${controls}">
-						${items.map((item, index) => `
+						${pages.map((page, index) => `
 							<div class="item" aria-label="${title({index})}">
 								${label({index})}
 							</div>`


### PR DESCRIPTION
This PR groups items into pages. Pages will be rendered with less dots inside the pagination than the current rendering behaviour. 

This also brings some breaking changes into the pagination template options. Instead of passing items, the pages will be passed. 

The `.pages` getter is now available on the instance api. This returns a list of grouped (item) indexes. Each group defines a page with the corresponding item indexes inside.