### PR TITLE
Always allow to scroll due to hidden scrollbar

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Caroucssel buttons should add buttons 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel has-invisible-scrollbar\\" id=\\"caroucssel-1\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -11,7 +11,7 @@ exports[`Caroucssel buttons should add buttons 1`] = `
 				
 					<div class=\\"item item-2\\">Item 2</div>
 				
-			</div>
+			</div></div>
 		<button type=\\"button\\" class=\\"button is-previous\\" aria-label=\\"Previous\\" title=\\"Go to previous\\" aria-controls=\\"caroucssel-1\\" disabled=\\"\\">
 		<span>Previous</span>
 	</button><button type=\\"button\\" class=\\"button is-next\\" aria-label=\\"Next\\" title=\\"Go to next\\" aria-controls=\\"caroucssel-1\\">
@@ -23,7 +23,7 @@ exports[`Caroucssel buttons should add buttons 1`] = `
 exports[`Caroucssel buttons should add buttons with custom options 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel has-invisible-scrollbar\\" id=\\"caroucssel-1\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -31,7 +31,7 @@ exports[`Caroucssel buttons should add buttons with custom options 1`] = `
 				
 					<div class=\\"item item-2\\">Item 2</div>
 				
-			</div>
+			</div></div>
 		<button type=\\"button\\" class=\\"custom-button-class custom-previous-button-class\\" aria-label=\\"Custom previous label\\" title=\\"Custom previous title\\" aria-controls=\\"caroucssel-1\\" disabled=\\"\\">
 		<span>Custom previous label</span>
 	</button><button type=\\"button\\" class=\\"custom-button-class custom-next-button-class\\" aria-label=\\"Custom next label\\" title=\\"Custom next title\\" aria-controls=\\"caroucssel-1\\">
@@ -43,7 +43,7 @@ exports[`Caroucssel buttons should add buttons with custom options 1`] = `
 exports[`Caroucssel buttons should add buttons with custom template 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel has-invisible-scrollbar\\" id=\\"custom-id\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"custom-id\\" style=\\"margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -51,7 +51,7 @@ exports[`Caroucssel buttons should add buttons with custom template 1`] = `
 				
 					<div class=\\"item item-2\\">Item 2</div>
 				
-			</div>
+			</div></div>
 		<span class=\\"custom-button-class custom-previous-button-class\\" title=\\"Custom previous title\\">Custom previous label</span><span class=\\"custom-button-class custom-next-button-class\\" title=\\"Custom next title\\">Custom next label</span></div>
 	"
 `;
@@ -59,7 +59,7 @@ exports[`Caroucssel buttons should add buttons with custom template 1`] = `
 exports[`Caroucssel pagination should add pagination 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel has-invisible-scrollbar\\" id=\\"caroucssel-1\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -67,7 +67,7 @@ exports[`Caroucssel pagination should add pagination 1`] = `
 				
 					<div class=\\"item item-2\\">Item 2</div>
 				
-			</div>
+			</div></div>
 		<ul class=\\"pagination\\">
 		<li>
 				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to 1. item\\" title=\\"Go to 1. item\\" disabled=\\"\\">
@@ -89,7 +89,7 @@ exports[`Caroucssel pagination should add pagination 1`] = `
 exports[`Caroucssel pagination should add pagination with custom options 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel has-invisible-scrollbar\\" id=\\"caroucssel-1\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -97,7 +97,7 @@ exports[`Caroucssel pagination should add pagination with custom options 1`] = `
 				
 					<div class=\\"item item-2\\">Item 2</div>
 				
-			</div>
+			</div></div>
 		<ul class=\\"custom-pagination-class\\">
 		<li>
 				<button type=\\"button\\" aria-controls=\\"caroucssel-1\\" aria-label=\\"Go to first item\\" title=\\"Go to first item\\" disabled=\\"\\">
@@ -119,7 +119,7 @@ exports[`Caroucssel pagination should add pagination with custom options 1`] = `
 exports[`Caroucssel pagination should add pagination with custom template 1`] = `
 "
 		<div class=\\"container\\">
-			<div class=\\"caroucssel has-invisible-scrollbar\\" id=\\"caroucssel-1\\">
+			<div class=\\"caroucssel-mask\\" style=\\"overflow: hidden; height: 100%;\\"><div class=\\"caroucssel\\" id=\\"caroucssel-1\\" style=\\"margin-bottom: 0px;\\">
 				
 					<div class=\\"item item-0\\">Item 0</div>
 				
@@ -127,7 +127,7 @@ exports[`Caroucssel pagination should add pagination with custom template 1`] = 
 				
 					<div class=\\"item item-2\\">Item 2</div>
 				
-			</div>
+			</div></div>
 		<div class=\\"custom-pagination-class\\" aria-controls=\\"caroucssel-1\\">
 						
 							<div class=\\"item\\" aria-label=\\"Go to first item\\">

--- a/src/caroucssel.scss
+++ b/src/caroucssel.scss
@@ -15,17 +15,6 @@
 		outline: none;
 		white-space: normal;
 	}
-
-	&.has-invisible-scrollbar {
-		&::-webkit-scrollbar,
-		&::-webkit-scrollbar-track {
-			background: transparent;
-		}
-	}
-
-	&.has-visible-scrollbar {
-		overflow: hidden;
-	}
 }
 
 @mixin caroucssel-snap($at: 100%) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,6 +62,7 @@ export type Options = {
 
 	// Scrollbars:
 	hasScrollbars?: boolean;
+	scrollbarsMaskClassName?: string;
 
 	// Hooks:
 	onScroll?: ScrollHook;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -339,41 +339,56 @@ describe('Caroucssel', () => {
 
 
 	describe('scrollbars', () => {
+		it('should wrap mask element', () => {
+			mockScrollbarDimensions = {width: 15, height: 15};
 
-		it('should detect invisible scrollbar of OS by adding classname', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+
+			new Carousel(el);
+			expect(el.parentNode.className).toBe('caroucssel-mask');
+			expect(el.parentNode.style.overflow).toBe('hidden');
+			expect(el.parentNode.style.height).toBe('100%');
+		});
+
+		it('should detect invisible scrollbar', () => {
 			mockScrollbarDimensions = {width: 0, height: 0};
 
 			document.body.innerHTML = __fixture(3);
 			const el = document.querySelector('.caroucssel');
+			const style = {};
+			Object.defineProperty(el, 'style', { value: style, writable: false });
 
 			new Carousel(el);
-			expect(Array.from(el.classList)).toEqual([
-				'caroucssel',
-				'has-invisible-scrollbar'
-			]);
+			expect(style).toEqual({
+				marginBottom: '0px',
+				height: 'calc(100% + 0px)',
+			});
 		});
 
-		it('should detect visible scrollbar of OS by adding classname', () => {
-			mockScrollbarDimensions = {width: 1, height: 1};
+		it('should detect visible scrollbar', () => {
+			mockScrollbarDimensions = {width: 15, height: 15};
 
 			document.body.innerHTML = __fixture(3);
 			const el = document.querySelector('.caroucssel');
+			const style = {};
+			Object.defineProperty(el, 'style', { value: style, writable: false });
 
 			new Carousel(el);
-			expect(Array.from(el.classList)).toEqual([
-				'caroucssel',
-				'has-visible-scrollbar'
-			]);
+			expect(style).toEqual({
+				marginBottom: '-15px',
+				height: 'calc(100% + 15px)',
+			});
 		});
 
-		it('should use css defaults by don\'t adding any classname', () => {
+		it('should use css defaults by not wrapping mask element', () => {
 			mockScrollbarDimensions = {width: 1, height: 1};
 
 			document.body.innerHTML = __fixture(3);
 			const el = document.querySelector('.caroucssel');
 
 			new Carousel(el, {hasScrollbars: true});
-			expect(Array.from(el.classList)).toEqual(['caroucssel']);
+			expect(el.getAttribute('style')).toBeNull();
 		});
 
 	});

--- a/web/styles.scss
+++ b/web/styles.scss
@@ -19,6 +19,7 @@
 }
 
 body {
+	overflow: hidden;
 	background: #2F2F2F;
 	color: #FFFFFF;
 	font-family: 'Vollkorn', serif;
@@ -91,7 +92,7 @@ a {
 	text-align: left;
 }
 
-.container {
+.caroucssel {
 	height: 100vh;
 }
 


### PR DESCRIPTION
This introduces a mask that creates a negative offset depending on the current scrollbar height. It allows to render the component with overflow: auto at any time. The scrollbar only gets hidden. So a user is able to scroll event if their OS has visible scrollbars.