### PR TITLE
Add filter for items

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ const carousel = new Carousel(el, {
 });
 ```
 
+##### Filters
+
+The carousel will ignore "invisible" html elements as scroll items by default. These elements are: `<link>`, `<meta>`, `<noscript>`, `<script>`, `<style>` and `<title>`. Other elements with a `hidden` attribute are ignored as well: `<div hidden>Hidden item</div>`.
+
+* `filterItem` allows to manually filter elements as items. This function is a regular filter function which receives the current element (and it's index as child element) and returns a boolean that flags if the element is a valid item.
+
+```javascript
+const carousel = new Carousel(el, {
+    filterItem: (item, index) => (index % 3) === 0
+});
+```
+
 ##### Events
 
 * `onScroll` a function which is invoked when the user scrolls through the carousel. An object containing the current `index` (a list of visible indexes), an event `type`, a reference to the carousel instance (`target`) and the original scroll event (`originalEvent`) is passed to the function.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,6 +42,10 @@ export type ScrollHook = (event: {
 	originalEvent: Event;
 }) => any;
 
+export type FilterItemFn =
+	((item: Element) => boolean) |
+	((item: Element, index: number) => boolean);
+
 export type Options = {
 	// Settings:
 	index?: number;
@@ -62,6 +66,9 @@ export type Options = {
 
 	// Scrollbars:
 	hasScrollbars?: boolean;
+
+	// Filter:
+	filterItem?: FilterItemFn;
 
 	// Hooks:
 	onScroll?: ScrollHook;

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,8 @@ const
 	CLASS_VISIBLE_SCROLLBAR = 'has-visible-scrollbar',
 	CLASS_INVISIBLE_SCROLLBAR = 'has-invisible-scrollbar',
 
+	INVISIBLE_ELEMENTS = /^(link|meta|noscript|script|style|title)$/i,
+
 	EVENT_SCROLL = 'scroll',
 	EVENT_RESIZE = 'resize',
 
@@ -58,6 +60,9 @@ const
 
 		// Scrollbars, set to true when use default scrolling behaviour
 		hasScrollbars: false,
+
+		// filter
+		filterItem: () => true,
 
 		// Hooks:
 		onScroll: null
@@ -104,7 +109,8 @@ export class Carousel {
 		this._options.buttonPrevious = {...DEFAULTS_BUTTON_PREVIOUS, ...options.buttonPrevious};
 		this._options.buttonNext = {...DEFAULTS_BUTTON_NEXT, ...options.buttonNext};
 
-		this._items = [...this.el.children];
+		// Receive all items:
+		this._updateItems();
 
 		// Render:
 		this._addButtons();
@@ -217,10 +223,18 @@ export class Carousel {
 
 	update() {
 		const {index} = this;
-		this._items = [...this.el.children];
+		this._updateItems();
 		this._updateButtons(index);
 		this._updatePagination(index);
 		this._updateScrollbars();
+	}
+
+	_updateItems() {
+		const { el, _options } = this;
+		this._items = Array
+			.from(el.children)
+			.filter((item) => !INVISIBLE_ELEMENTS.test(item.tagName) && !item.hidden)
+			.filter(_options.filterItem);
 	}
 
 	_updateScrollbars() {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -168,6 +168,88 @@ describe('Caroucssel', () => {
 			expect(carousel.index).toEqual([2, 3]);
 		});
 
+		it('should ignore <link> in items', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+			const hidden = document.createElement('link');
+			el.appendChild(hidden);
+
+			const carousel = new Carousel(el);
+			expect(carousel.items).toHaveLength(3);
+		});
+
+		it('should ignore <link> in items', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+			const hidden = document.createElement('link');
+			el.appendChild(hidden);
+
+			const carousel = new Carousel(el);
+			expect(carousel.items).toHaveLength(3);
+		});
+
+		it('should ignore <noscript> in items', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+			const hidden = document.createElement('noscript');
+			el.appendChild(hidden);
+
+			const carousel = new Carousel(el);
+			expect(carousel.items).toHaveLength(3);
+		});
+
+		it('should ignore <script> in items', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+			const hidden = document.createElement('script');
+			el.appendChild(hidden);
+
+			const carousel = new Carousel(el);
+			expect(carousel.items).toHaveLength(3);
+		});
+
+		it('should ignore <style> in items', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+			const hidden = document.createElement('style');
+			el.appendChild(hidden);
+
+			const carousel = new Carousel(el);
+			expect(carousel.items).toHaveLength(3);
+		});
+
+		it('should ignore <title> in items', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+			const hidden = document.createElement('title');
+			el.appendChild(hidden);
+
+			const carousel = new Carousel(el);
+			expect(carousel.items).toHaveLength(3);
+		});
+
+		it('should ignore with "hidden" attribute in items', () => {
+			document.body.innerHTML = __fixture(3);
+			const el = document.querySelector('.caroucssel');
+			el.children[0].hidden = true;
+
+			const hidden = document.createElement('div');
+			hidden.setAttribute('hidden', 'hidden');
+			el.appendChild(hidden);
+
+			const carousel = new Carousel(el);
+			expect(carousel.items).toHaveLength(2);
+		});
+
+		it('should filter items based on filter function', () => {
+			document.body.innerHTML = __fixture(9);
+			const el = document.querySelector('.caroucssel');
+			const carousel = new Carousel(el, {
+				filterItem: (item, index) => (index % 3) === 0
+			});
+			expect(carousel.items).toHaveLength(3);
+		});
+
 	});
 
 


### PR DESCRIPTION
The carousel will ignore "invisible" html elements as scroll items by default. These elements are: `<link>`, `<meta>`, `<noscript>`, `<script>`, `<style>` and `<title>`. Other elements with a `hidden` attribute are ignored as well: `<div hidden>Hidden item</div>`.

To manually filter elements as items, the `filterItem` function can be used. This function is a regular filter function which receives the current element (and it's index as child element) and returns a boolean that flags if the element is a valid item:

```javascript
const carousel = new Carousel(el, {
    filterItem: (item, index) => (index % 3) === 0
});
```