### PR TITLE
Fix calculation of pages at element width of 0px

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,9 +200,17 @@ export class Carousel {
 
 	get pages() {
 		const {el, items} = this;
-		const {clientWidth} = el;
-		const pages = [[]];
 
+		const {clientWidth} = el;
+		if (clientWidth === 0) {
+			// if the width of the carousel element is zero, we can not calculate
+			// the pages properly and the carousel seems to be not visible. If
+			// this is the case, we assume that each item is placed on a
+			// separate page.
+			return items.map((item, index) => [index]);
+		}
+
+		const pages = [[]];
 		items.forEach((item, index) => {
 			const {offsetLeft, clientWidth: width} = item;
 			// at least 90% of the items needs to be in the page:

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -240,6 +240,18 @@ describe('Caroucssel', () => {
 			]);
 		});
 
+		it('should return pages for each item when element width is 0px', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockWidth = 0;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockWidth = 100);
+
+			const carousel = new Carousel(el);
+			expect(carousel.pages).toEqual([
+				[0], [1], [2], [3], [4], [5], [6], [7], [8], [9],
+			]);
+		});
+
 		it('should ignore <link> in items', () => {
 			document.body.innerHTML = __fixture(3);
 			const el = document.querySelector('.caroucssel');

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -168,6 +168,78 @@ describe('Caroucssel', () => {
 			expect(carousel.index).toEqual([2, 3]);
 		});
 
+		it('should return pages when each item is at 100% width', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockWidth = 100);
+
+			const carousel = new Carousel(el);
+			expect(carousel.pages).toEqual([
+				[0], [1], [2], [3], [4], [5], [6], [7], [8], [9],
+			]);
+		});
+
+		it('should return pages when each item is at 75% width', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockWidth = 75);
+
+			const carousel = new Carousel(el);
+			expect(carousel.pages).toEqual([
+				[0], [1], [2, 3], [4], [5], [6, 7], [8], [9],
+			]);
+		});
+
+		it('should return pages when each item is at 66.66% width', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockWidth = 66.66);
+
+			const carousel = new Carousel(el);
+			expect(carousel.pages).toEqual([
+				[0], [1, 2], [3], [4, 5], [6], [7, 8], [9],
+			]);
+		});
+
+		it('should return pages when each item is at 50% width', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockWidth = 50);
+
+			const carousel = new Carousel(el);
+			expect(carousel.pages).toEqual([
+				[0, 1], [2, 3], [4, 5], [6, 7], [8, 9],
+			]);
+		});
+
+		it('should return pages when each item is at 33.33% width', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockWidth = 33.33);
+
+			const carousel = new Carousel(el);
+			expect(carousel.pages).toEqual([
+				[0, 1, 2], [3, 4, 5], [6, 7, 8], [9],
+			]);
+		});
+
+		it('should return pages when item is at 0px width', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockWidth = 0);
+
+			const carousel = new Carousel(el);
+			expect(carousel.pages).toEqual([
+				[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+			]);
+		});
+
 		it('should ignore <link> in items', () => {
 			document.body.innerHTML = __fixture(3);
 			const el = document.querySelector('.caroucssel');


### PR DESCRIPTION
When the carousel container uses a width of 0px, the calculation fails to determine the correct page index. There will be a division by `0` which causes the carousel to add the current item to a page with the index `NaN`. To prevent that behavior and return a more predictable return value, this case is handled specifically and each item is placed on a single page.