### PR TITLE
Set initial index only if defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,18 +120,19 @@ export class Carousel {
 		this._id = el.id;
 
 		// "deep" extend options and defaults:
-		this._options = {...DEFAULTS, ...options};
-		this._options.buttonPrevious = {...DEFAULTS_BUTTON_PREVIOUS, ...options.buttonPrevious};
-		this._options.buttonNext = {...DEFAULTS_BUTTON_NEXT, ...options.buttonNext};
+		const opts = { ...DEFAULTS, ...options };
+		opts.buttonPrevious = {...DEFAULTS_BUTTON_PREVIOUS, ...options.buttonPrevious};
+		opts.buttonNext = {...DEFAULTS_BUTTON_NEXT, ...options.buttonNext};
+		this._options = opts;
 
 		// Render:
 		this._addButtons();
 		this._addPagination();
 		this._updateScrollbars();
 
-		// Set index:
+		// Set initial index and set smooth scrolling:
 		this._isSmooth = false;
-		this.index = this._options.index || this.pages[0];
+		this.index = options.index;
 		this._isSmooth = true;
 
 		// Events:
@@ -181,6 +182,10 @@ export class Carousel {
 	set index(values) {
 		const {el, items} = this;
 		const {length} = items;
+
+		if (!Array.isArray(values) || !values.length) {
+			return;
+		}
 
 		if (length === 0) {
 			return;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -153,11 +153,64 @@ describe('Caroucssel', () => {
 			expect(carousel.index).toEqual([0]);
 		});
 
-		it('should set initial index as option', () => {
+		it('should not set initial index when option is undefined (default)', () => {
 			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
 			const el = document.querySelector('.caroucssel');
+			el.mockClientWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockClientWidth = 100);
+
+			const scrollTo = jest.spyOn(el, 'scrollTo');
+			const carousel = new Carousel(el, {index: undefined});
+			expect(carousel.index).toEqual([0]);
+			expect(scrollTo).not.toHaveBeenCalled();
+		});
+
+		it('should not set initial index when option is an empty array', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockClientWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockClientWidth = 100);
+
+			const scrollTo = jest.spyOn(el, 'scrollTo');
+			const carousel = new Carousel(el, {index: []});
+			expect(carousel.index).toEqual([0]);
+			expect(scrollTo).not.toHaveBeenCalled();
+		});
+
+		it('should not set initial index when option is a number', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockClientWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockClientWidth = 100);
+
+			const scrollTo = jest.spyOn(el, 'scrollTo');
+			const carousel = new Carousel(el, {index: 4});
+			expect(carousel.index).toEqual([0]);
+			expect(scrollTo).not.toHaveBeenCalled();
+		});
+
+		it('should set initial index by option', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockClientWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockClientWidth = 100);
+
+			const scrollTo = jest.spyOn(el, 'scrollTo');
 			const carousel = new Carousel(el, {index: [2]});
 			expect(carousel.index).toEqual([2]);
+			expect(scrollTo).toHaveBeenCalled();
+		});
+
+		it('should set initial index when option is [0]', () => {
+			document.body.innerHTML = __fixture(10, {id: 'custom-id'});
+			const el = document.querySelector('.caroucssel');
+			el.mockClientWidth = 100;
+			[...document.querySelectorAll('.item')].forEach((item) => item.mockClientWidth = 100);
+
+			const scrollTo = jest.spyOn(el, 'scrollTo');
+			const carousel = new Carousel(el, {index: [0]});
+			expect(carousel.index).toEqual([0]);
+			expect(scrollTo).toHaveBeenCalled();
 		});
 
 		it('should set initial index as option when multiple items are visible', () => {


### PR DESCRIPTION
This disables the initial setup if an index by default. It will only be defined if its passed by the options. Otherwise the carousel will keep the initial position as defined by CSS.